### PR TITLE
Fix order of arguments to calloc

### DIFF
--- a/cwolfmap/zip/zip.c
+++ b/cwolfmap/zip/zip.c
@@ -1673,7 +1673,7 @@ ssize_t zip_stream_copy(struct zip_t *zip, void **buf, size_t *bufsize) {
     *bufsize = n;
   }
 
-  *buf = calloc(sizeof(unsigned char), n);
+  *buf = calloc(n, sizeof(unsigned char));
   memcpy(*buf, zip->archive.m_pState->m_pMem, n);
 
   return (ssize_t)n;


### PR DESCRIPTION
first argument is the number, second argument the size.

found by gcc 14 (calloc-transposed-args)

---

cdogs-sdl fails to build in Debian with gcc-14: https://bugs.debian.org/1074873

```
/<<PKGBUILDDIR>>/src/cdogs/cwolfmap/zip/zip.c:1676:24: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
 1676 |   *buf = calloc(sizeof(unsigned char), n);
      |                        ^~~~~~~~
/<<PKGBUILDDIR>>/src/cdogs/cwolfmap/zip/zip.c:1676:24: note: earlier argument should specify number of elements, later size of each element
```

please import this fix also into cdogs-sdl.